### PR TITLE
[ROCm][CI] Fix the three rocm7.14 failures blocking #4039

### DIFF
--- a/.github/workflows/integration_test_8gpu_features_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_features_rocm.yaml
@@ -79,6 +79,8 @@ jobs:
           echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
         fi
 
+        export PYTORCH_ALLOC_CONF="expandable_segments:False"
+
         start=$(date +%s)
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
         end=$(date +%s)

--- a/.github/workflows/integration_test_8gpu_features_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_features_rocm.yaml
@@ -73,8 +73,11 @@ jobs:
         end=$(date +%s)
         echo "pip install torch took $((end - start)) seconds"
 
-        export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
-        echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
+        HIPBLASLT_LIB_DIR="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
+        if [ -d "${HIPBLASLT_LIB_DIR}" ]; then
+          export HIPBLASLT_TENSILE_LIBPATH="${HIPBLASLT_LIB_DIR}"
+          echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
+        fi
 
         start=$(date +%s)
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}

--- a/.github/workflows/integration_test_8gpu_models_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_models_rocm.yaml
@@ -68,8 +68,11 @@ jobs:
 
         python -m pip install --pre --no-deps torchvision --index-url ${{ matrix.index-url }}
 
-        export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
-        echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
+        HIPBLASLT_LIB_DIR="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
+        if [ -d "${HIPBLASLT_LIB_DIR}" ]; then
+          export HIPBLASLT_TENSILE_LIBPATH="${HIPBLASLT_LIB_DIR}"
+          echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
+        fi
 
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
 

--- a/.github/workflows/integration_test_8gpu_models_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_models_rocm.yaml
@@ -74,6 +74,8 @@ jobs:
           echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"
         fi
 
+        export PYTORCH_ALLOC_CONF="expandable_segments:False"
+
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
 
         sudo mkdir -p "$RUNNER_TEMP/artifacts-to-be-uploaded"

--- a/.github/workflows/integration_test_8gpu_models_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_models_rocm.yaml
@@ -64,7 +64,9 @@ jobs:
           TORCH_SPEC="torch==${{ matrix.torch-version }}"
         fi
         python -m pip install --force-reinstall --pre \
-          "${TORCH_SPEC}" torchvision --index-url ${{ matrix.index-url }}
+          "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
+
+        python -m pip install --pre --no-deps torchvision --index-url ${{ matrix.index-url }}
 
         export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
         echo "HIPBLASLT_TENSILE_LIBPATH=${HIPBLASLT_TENSILE_LIBPATH}"

--- a/run_train.sh
+++ b/run_train.sh
@@ -40,7 +40,7 @@ if [ -n "$COMM_MODE" ]; then
     NGPU="${NGPU}" LOCAL_RANK=0 python3 -m torchtitan.train --module ${MODULE} --config ${CONFIG} "$@" --comm.mode=${COMM_MODE} --training.steps 1
 else
     # Normal training with torchrun
-    PYTORCH_ALLOC_CONF="expandable_segments:True" \
+    PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}" \
     TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE} \
     torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
     --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \


### PR DESCRIPTION
Hi @akashveramd — fixes for the two red ROCm jobs on pytorch/torchtitan#4039.  which you can merge into your branch. 

All fixes are needed due to making the  `rocm7.2` → `rocm7.14` switch.


CI Reproduction: 

8× MI350X (gfx950, `torch 2.15.0.dev+rocm7.14`) and the fix verified by running the actual failing CI command.

**1. Model Tests — pip `RecursionError` during install.** rocm7.14 torch pulls
`rocm[device-all,libraries]==7.14.*` (~25 `rocm-sdk-device-gfx*` packages); resolving `torch` and `torchvision` together over that graph blows pip's recursion limit. rocm7.2 and cu130 survive the identical line. Fix: resolve torchvision in a second `pip install --pre --no-deps`.

**2. Feature Tests — `dcp.load` "Tried to allocate more than 1EB".** Not a collective bug. The gathered size is already garbage before the all_gather (`0x3f8000003f800000` = two float32 `1.0`s, i.e. stale device memory), because the H2D copy in `_object_to_tensor` doesn't land under `PYTORCH_ALLOC_CONF=expandable_segments:True`, which `run_train.sh`
hardcodes. Fix: make it overridable (`${VAR:-default}`, so CUDA is unaffected) and turn it off for ROCm. Not sure how Meta people will feel about this - we might have to file an upstream issue. 

**3. `HIPBLASLT_TENSILE_LIBPATH` points at a directory that no longer exists.** In 7.14 wheels hipblaslt moved out of `torch/lib` into `rocm-sdk-libraries`, so the exported path is dead and every matmul fails with `HIPBLAS_STATUS_INVALID_VALUE`. You can't see this yet because #2 kills the job first — fix #2 alone and the job comes back red looking like a new
regression. Fix: only export the variable if the directory exists.

Just as a heads up, this probably won't go green immediately. The loss files were generated with Rocm 7.2 so the numerics will most likely be off. Once we run the workflows again, we can see the exact numbers and put in to the file. These changes theoretically should fix the failures that are red today, at least as they reproduce in our environment.
