### PR TITLE
[ROCm][CI] Add --force-reinstall to the torchvision install

### DIFF
--- a/.github/workflows/integration_test_8gpu_models_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_models_rocm.yaml
@@ -66,7 +66,7 @@ jobs:
         python -m pip install --force-reinstall --pre \
           "${TORCH_SPEC}" --index-url ${{ matrix.index-url }}
 
-        python -m pip install --pre --no-deps torchvision --index-url ${{ matrix.index-url }}
+        python -m pip install --force-reinstall --pre --no-deps torchvision --index-url ${{ matrix.index-url }}
 
         HIPBLASLT_LIB_DIR="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
         if [ -d "${HIPBLASLT_LIB_DIR}" ]; then


### PR DESCRIPTION
One-line follow-up to #3.

The CI image preinstalls torchvision 0.28.0 (built against torch 2.13.0). Without
`--force-reinstall`, pip reports it as already satisfied and leaves it in place, so its `_C`
extension can't load against the torch 2.15 nightly and `import torchvision` raises
`RuntimeError: operator torchvision::nms does not exist` — which is what failed the three
multimodal flavors and `qwen3_5_moe` in the last run.

Verified against the same already-satisfied path: reinstalls to 0.30.0.dev20260817+rocm7.14,
leaves torch untouched, `torchvision.ops.nms` and `torchvision.io` both work. `--no-deps`
keeps the resolver to a single node, so this can't bring back the RecursionError.
