### PR TITLE
[ROCm][CI] Skip Qwen3 MoE loss parity check (exploding gradients on ROCm 7.14)

### DIFF
--- a/.github/workflows/integration_test_8gpu_features_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_features_rocm.yaml
@@ -117,6 +117,17 @@ jobs:
         # Skipped on ROCm 7.14: exploding gradients in Qwen3 MoE TP+EP training
         # (https://github.com/pytorch/pytorch/issues/194004). Remove skip when
         # pytorch has ROCm 7.15.
+        # MoE loss comparison: verify Qwen3 MoE FSDP+TP+EP deterministic losses match reference
+        # MOE_LOSS_FILE="tests/assets/losses/qwen3_moe_rocm_mi350x.txt"
+        #
+        # echo "Checking Qwen3 MoE FSDP+TP+EP loss parity against reference"
+        # python3 scripts/loss_compare.py . . \
+        #   --baseline-module=qwen3 --baseline-config=qwen3_moe_debug \
+        #   --baseline-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
+        #   --test-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
+        #   --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/moe_loss_comparison" \
+        #   --import-result="${MOE_LOSS_FILE}" --assert-equal --steps=100
+        # rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
         python -m tests.integration_tests.run_tests --gpu_arch_type ${{ matrix.gpu-arch-type }} --test_suite features $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
 

--- a/.github/workflows/integration_test_8gpu_features_rocm.yaml
+++ b/.github/workflows/integration_test_8gpu_features_rocm.yaml
@@ -114,17 +114,9 @@ jobs:
         python3 scripts/loss_compare.py . . --baseline-options="${baseline_options}" --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/accuracy_comparison_outputs" --import-result="${LOSS_FILE}" --assert-equal --steps=100
         rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
 
-        # MoE loss comparison: verify Qwen3 MoE FSDP+TP+EP deterministic losses match reference
-        MOE_LOSS_FILE="tests/assets/losses/qwen3_moe_rocm_mi350x.txt"
-
-        echo "Checking Qwen3 MoE FSDP+TP+EP loss parity against reference"
-        python3 scripts/loss_compare.py . . \
-          --baseline-module=qwen3 --baseline-config=qwen3_moe_debug \
-          --baseline-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
-          --test-options="--parallelism.tensor_parallel_degree 2 --parallelism.expert_parallel_degree 4" \
-          --job-dump-folder="${RUNNER_TEMP}/artifacts-to-be-uploaded/moe_loss_comparison" \
-          --import-result="${MOE_LOSS_FILE}" --assert-equal --steps=100
-        rm -rf $RUNNER_TEMP/artifacts-to-be-uploaded/*
+        # Skipped on ROCm 7.14: exploding gradients in Qwen3 MoE TP+EP training
+        # (https://github.com/pytorch/pytorch/issues/194004). Remove skip when
+        # pytorch has ROCm 7.15.
 
         python -m tests.integration_tests.run_tests --gpu_arch_type ${{ matrix.gpu-arch-type }} --test_suite features $RUNNER_TEMP/artifacts-to-be-uploaded --ngpu 8
 


### PR DESCRIPTION
Skips the Qwen3 MoE FSDP+TP+EP loss parity check on ROCm only (CUDA workflow untouched).

Root cause: exploding gradients (NaN) in Qwen3 MoE TP+EP training on ROCm 7.14 —
https://github.com/pytorch/pytorch/issues/194004. ROCm 7.15 fixes this, but it
isn't in a pytorch nightly yet. We should be able to remove the skip in ~2 weeks.
