### PR TITLE
[ROCm][CI] Fix HIPBLASLT path and expandable_segments OOM

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -104,7 +104,11 @@ jobs:
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.index-url }}
 
         if [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
-          export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
+          HIPBLASLT_LIB_DIR="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
+          if [ -d "${HIPBLASLT_LIB_DIR}" ]; then
+            export HIPBLASLT_TENSILE_LIBPATH="${HIPBLASLT_LIB_DIR}"
+          fi
+          export PYTORCH_ALLOC_CONF="expandable_segments:False"
         fi
 
         sudo mkdir -p "$RUNNER_ARTIFACT_DIR"
@@ -171,7 +175,11 @@ jobs:
         USE_CPP=0 python -m pip install --pre torchao --index-url ${{ matrix.runner_config['index-url'] }}
 
         if [[ "${{ matrix.runner_config['gpu-arch-type'] }}" == "rocm" ]]; then
-          export HIPBLASLT_TENSILE_LIBPATH="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
+          HIPBLASLT_LIB_DIR="$(python -c 'import os, torch; print(os.path.join(os.path.dirname(torch.__file__), "lib", "hipblaslt", "library"))')"
+          if [ -d "${HIPBLASLT_LIB_DIR}" ]; then
+            export HIPBLASLT_TENSILE_LIBPATH="${HIPBLASLT_LIB_DIR}"
+          fi
+          export PYTORCH_ALLOC_CONF="expandable_segments:False"
         fi
 
         sudo mkdir -p "$RUNNER_ARTIFACT_DIR"

--- a/run_train.sh
+++ b/run_train.sh
@@ -38,7 +38,7 @@ if [ "$COMM_MODE" = "fake_backend" ]; then
     NGPU="${NGPU}" LOCAL_RANK=0 python3 -m torchtitan.train --module ${MODULE} --config ${CONFIG} --comm.mode=fake_backend --training.steps 1 "$@"
 else
     # Normal training with torchrun
-    PYTORCH_ALLOC_CONF="expandable_segments:True" \
+    PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}" \
     TORCHFT_LIGHTHOUSE=${TORCHFT_LIGHTHOUSE} \
     torchrun --nproc_per_node=${NGPU} --rdzv_backend c10d --rdzv_endpoint="localhost:0" \
     --local-ranks-filter ${LOG_RANK} --role rank --tee 3 \


### PR DESCRIPTION
Fixes both ROCm jobs currently failing on this PR
(`8 GPU Integration (Real PG - full suite - features/models)`).

Reproduced and validated on 8x MI350X against the current PR head
(`fa3d1f2e`, today's `rocm10.0` nightly stack). Both bugs are on the
checkpoint-load path and are independent — fixing only one still leaves
the job red.

### 1. `HIPBLASLT_TENSILE_LIBPATH` points at a directory that no longer exists

Both `integration-fake-pg` and `integration-real-pg` unconditionally export:
```bash
export HIPBLASLT_TENSILE_LIBPATH="$(python -c '...os.path.join(...torch.__file__..., "lib", "hipblaslt", "library")')"
```
In current ROCm nightly wheels, hipblaslt's kernel library no longer ships
under `<torch>/lib/hipblaslt/library` — it moved into a separate
`rocm-sdk-libraries` package. That directory is empty/absent, so exporting
it overrides hipblaslt's own (working) internal search path with a dead one:
```
rocblaslt error: Cannot read ".../hipblaslt/library/TensileLibrary_lazy_gfx950.dat"
```
and every matmul that touches hipblaslt fails.

**Fix:** only export the variable if the directory actually exists. If it
doesn't, we simply don't set it, and hipblaslt falls back to its own default
search path, which does resolve the SDK's real library location. Confirmed:
no `rocblaslt error` with the guard in place.

### 2. `expandable_segments:True` corrupts a small host→device copy during checkpoint load

`run_train.sh` hardcodes `PYTORCH_ALLOC_CONF="expandable_segments:True"`.
During `dcp.load`, `dist.gather_object` calls `_object_to_tensor`, which
copies a small pickled object's byte-length (an int64) host→device before
an `all_gather`. Under `expandable_segments:True` on ROCm, that particular
copy doesn't reliably land — the destination tensor holds stale device
memory instead. Instrumenting this directly showed the garbage value read
was `0x3f8000003f800000` — two float32 `1.0`s, i.e. leftover norm-weight
data from a recycled allocator block, not a real size. That garbage size is
then passed to `tensor.resize_()`:
```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate more than 1EB memory.
```
It isn't really an OOM — it's memory corruption reported as one.

**Fix, two parts:**
- `run_train.sh`: `PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}"`
- Both ROCm workflow blocks: `export PYTORCH_ALLOC_CONF="expandable_segments:False"`

**This does not change PyTorch's or torchtitan's general/default behavior.**
`${VAR:-default}` only substitutes the default when the caller hasn't set
the variable — so CUDA jobs, H100 jobs, TorchFT, RL, and anyone invoking
`./run_train.sh` directly all get the exact same `expandable_segments:True`
as before, byte-for-byte. Only the two ROCm CI blocks, which now explicitly
set the variable themselves, get the different value. It's an opt-in
override at the one call site that needs it, not a change to any default.

### Validation

With both fixes, on the current PR head + today's `rocm10.0` stack:
```
Finished loading the checkpoint in 0.13 seconds.
step: 1  loss: 8.04909  grad_norm: 1.4054
step: 2  loss: 7.75184  grad_norm: 1.4844
```
No `rocblaslt error`, no `OutOfMemoryError`, training proceeds normally.
